### PR TITLE
Only run abricate once part 2

### DIFF
--- a/flanker.py
+++ b/flanker.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
 """
 Creates fasta for gene flanks
 """


### PR DESCRIPTION
This pull request allows users to specify a list of genes -log to be run meaning that one could for example run every gene in resfinder but only have to run abricate once. Alternatively users can supply a single gene to the command line as before -goi